### PR TITLE
Fix outliner visibility context

### DIFF
--- a/DH_Toolkit/operators/display_utils.py
+++ b/DH_Toolkit/operators/display_utils.py
@@ -36,7 +36,11 @@ class DH_OT_ToggleVisibilityOutliner(bpy.types.Operator):
     bl_description = "Toggle the visibility (eye icon) for selected objects in the Outliner"
 
     def execute(self, context):
-        selected_ids = bpy.context.selected_ids  # Get selected items in the Outliner
+        # Prefer selected_ids from the passed-in context (Blender 3.6+)
+        # but fall back to bpy.context for compatibility with older versions
+        selected_ids = getattr(context, "selected_ids", None)
+        if selected_ids is None:
+            selected_ids = getattr(bpy.context, "selected_ids", None)
 
         if not selected_ids:
             self.report({'WARNING'}, "No objects selected in the Outliner.")


### PR DESCRIPTION
## Summary
- fix toggling visibility when context.selected_ids exists by checking context first and falling back to bpy.context

## Testing
- `python -m py_compile DH_Toolkit/operators/display_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68414ad706048329b8dbda7f10f3b654