### PR TITLE
Fix open project directory operator

### DIFF
--- a/DH_Toolkit/operators/open_proj_dir.py
+++ b/DH_Toolkit/operators/open_proj_dir.py
@@ -1,24 +1,35 @@
 import bpy
 import os
+import sys
+import subprocess
+import webbrowser
 
 
 class DH_OP_Open_Proj_Dir(bpy.types.Operator):
-    """Set the diffuse color of the active material"""
+    """Open the project root directory in the system file manager."""
     bl_idname = "dh.open_proj_dir"
     bl_label = "Open Project"
 
     def execute(self, context):
 
-     # get the path of the current blend file
-     filepath = bpy.data.filepath
+        # get the path of the current blend file
+        filepath = bpy.data.filepath
 
-     # get the directory path
-     directory = os.path.dirname(filepath)
+        # get the directory path
+        directory = os.path.dirname(filepath)
 
-     # go up two folders
-     directory = os.path.abspath(os.path.join(directory, os.pardir, os.pardir))
+        # go up two folders
+        directory = os.path.abspath(os.path.join(directory, os.pardir, os.pardir))
 
-     # open the directory in explorer
-     os.startfile(directory)
-     
-     return {'FINISHED'}
+        # open the directory in the system file manager
+        try:
+            if sys.platform.startswith("win"):
+                subprocess.run(["start", directory], check=True, shell=True)
+            elif sys.platform == "darwin":
+                subprocess.run(["open", directory], check=True)
+            else:
+                subprocess.run(["xdg-open", directory], check=True)
+        except Exception:
+            webbrowser.open(directory)
+
+        return {'FINISHED'}


### PR DESCRIPTION
## Summary
- open project root directory cross-platform
- clarify operator docstring
- add missing newline at EOF

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684368116a288329aa38932bab11cb23