### PR TITLE
Fix project manager folder display and revert open project dir operator

### DIFF
--- a/DH_Toolkit/operators/open_proj_dir.py
+++ b/DH_Toolkit/operators/open_proj_dir.py
@@ -1,8 +1,5 @@
 import bpy
 import os
-import sys
-import subprocess
-import webbrowser
 
 
 class DH_OP_Open_Proj_Dir(bpy.types.Operator):
@@ -11,7 +8,6 @@ class DH_OP_Open_Proj_Dir(bpy.types.Operator):
     bl_label = "Open Project"
 
     def execute(self, context):
-
         # get the path of the current blend file
         filepath = bpy.data.filepath
 
@@ -21,15 +17,7 @@ class DH_OP_Open_Proj_Dir(bpy.types.Operator):
         # go up two folders
         directory = os.path.abspath(os.path.join(directory, os.pardir, os.pardir))
 
-        # open the directory in the system file manager
-        try:
-            if sys.platform.startswith("win"):
-                subprocess.run(["start", directory], check=True, shell=True)
-            elif sys.platform == "darwin":
-                subprocess.run(["open", directory], check=True)
-            else:
-                subprocess.run(["xdg-open", directory], check=True)
-        except Exception:
-            webbrowser.open(directory)
+        # open the directory in explorer
+        os.startfile(directory)
 
         return {'FINISHED'}

--- a/DH_Toolkit/operators/project_manager.py
+++ b/DH_Toolkit/operators/project_manager.py
@@ -35,22 +35,31 @@ class DH_OP_Proj_Manage(bpy.types.Operator):
     folder_items: bpy.props.CollectionProperty(type=PM_FolderItem)
 
     def _add_default_folders(self):
+        """Populate the folder list with a default hierarchy."""
         defaults = [
+            "01_Ref",
             os.path.join("01_Ref", "PR"),
+            "02_Photoshop",
             os.path.join("02_Photoshop", "PSD"),
             os.path.join("02_Photoshop", "images"),
+            "03_Blender",
             os.path.join("03_Blender", "Scenes"),
             os.path.join("03_Blender", "FBX"),
             os.path.join("03_Blender", "Textures"),
             os.path.join("03_Blender", "Renders"),
+            "04_Substance",
             os.path.join("04_Substance", "Scenes"),
             os.path.join("04_Substance", "FBX"),
             os.path.join("04_Substance", "Textures"),
+            os.path.join("04_Substance", "Textures", "01_Painter"),
+            os.path.join("04_Substance", "Textures", "02_Designer"),
             os.path.join("04_Substance", "SBS"),
             os.path.join("04_Substance", "SBSAR"),
+            "05_Resolve",
             os.path.join("05_Resolve", "Resources"),
             os.path.join("05_Resolve", "Stills"),
             os.path.join("05_Resolve", "Videos"),
+            "06_Daz",
         ]
         for path in defaults:
             item = self.folder_items.add()
@@ -103,7 +112,7 @@ class DH_OP_Proj_Manage(bpy.types.Operator):
             for _ in range(indent):
                 sub.label(text="", icon='BLANK1')
             icon = 'FILE_FOLDER' if indent == 0 else 'FILE_CACHE'
-            sub.label(text=item.path, icon=icon)
+            sub.label(text=os.path.basename(item.path), icon=icon)
             op = row.operator("dh.pm_add_subfolder", text="", icon='ADD')
             op.index = i
             op = row.operator("dh.pm_remove_folder", text="", icon='REMOVE')


### PR DESCRIPTION
## Summary
- restore previous open project directory implementation
- show hierarchy correctly in Project Manager defaults
- simplify folder labels to show only names

## Testing
- `python -m py_compile DH_Toolkit/operators/project_manager.py DH_Toolkit/operators/open_proj_dir.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a38835008329ab03e25711ac9574