### PR TITLE
Add Face Sets submenu

### DIFF
--- a/DH_Toolkit/menus/sculpt_menu.py
+++ b/DH_Toolkit/menus/sculpt_menu.py
@@ -14,6 +14,19 @@ class DH_MT_Sculpt_Menu(bpy.types.Menu):
         # LEFT - Brush Tools
         col_left = pie.column()
 
+        # Face Sets Tools
+        face_box = col_left.box()
+        face_box.label(text='Face Sets')
+
+        row = face_box.row(align=True)
+        row.operator('sculpt.face_sets_create', text='From Masked').mode = 'MASKED'
+        row.operator('sculpt.face_sets_create', text='From Visible').mode = 'VISIBLE'
+
+        row = face_box.row(align=True)
+        row.operator('sculpt.face_sets_create', text='From Edit Selection').mode = 'EDIT_MESH_SELECTION'
+        row.operator('sculpt.face_sets_init', text='Init Loose Parts').mode = 'LOOSE_PARTS'
+
+        # Brushes
         brush_box = col_left.box()
         brush_box.label(text='Brushes')
 


### PR DESCRIPTION
## Summary
- add new Face Sets tools box above Sculpt Toolkit brushes

## Testing
- `python -m py_compile DH_Toolkit/menus/sculpt_menu.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844301144bc83298a59d83392c1fe41