### PR TITLE
Fix FBX export versioning logic

### DIFF
--- a/DH_Toolkit/operators/export_fbx_multi.py
+++ b/DH_Toolkit/operators/export_fbx_multi.py
@@ -70,10 +70,27 @@ class DH_OP_dcc_split_export(bpy.types.Operator):
             pass # Folder exists or is created
 
         # Decide which version number to use
+        if version_num > 0:
+            latest_version_folder = os.path.join(
+                split_fbx_directory, f"v{str(version_num).zfill(3)}"
+            )
+
         if self.overwrite:
             version_to_use = max(1, version_num)
         else:
-            version_to_use = version_num + 1
+            if version_num == 0:
+                version_to_use = 1
+            else:
+                file_exists = False
+                for obj in selected_objects:
+                    check_path = os.path.join(latest_version_folder, f"{obj.name}.fbx")
+                    if os.path.exists(check_path):
+                        file_exists = True
+                        break
+                if file_exists:
+                    version_to_use = version_num + 1
+                else:
+                    version_to_use = version_num
 
         version_folder = os.path.join(split_fbx_directory, f"v{str(version_to_use).zfill(3)}")
         os.makedirs(version_folder, exist_ok=True)


### PR DESCRIPTION
## Summary
- add `ignore_suffix` option to DCC exporter
- only create a new version folder if an FBX with the same name exists
- perform the same version check for multi FBX export

## Testing
- `python -m py_compile DH_Toolkit/operators/DCC_Export.py DH_Toolkit/operators/export_fbx_multi.py`

------
https://chatgpt.com/codex/tasks/task_e_684433d246ec8329a3bf4e7fc301482a