### PR TITLE
Enhance multires operators

### DIFF
--- a/DH_Toolkit/menus/modifers_multires_menu.py
+++ b/DH_Toolkit/menus/modifers_multires_menu.py
@@ -19,4 +19,5 @@ def draw_modifiers_multires_menu(layout, context):
     layout.operator('dh.set_multires_viewport_max', text="Set Multires Max",icon_value=icon.icon_id)
     icon = icons.get("icon_cube")
     layout.operator('dh.set_multires_viewport_zero', text="Set Multires Min",icon_value=icon.icon_id)
+    layout.operator('dh.apply_multires_base', text="Apply Base")
 

--- a/DH_Toolkit/menus/sculpt_menu.py
+++ b/DH_Toolkit/menus/sculpt_menu.py
@@ -136,6 +136,7 @@ class DH_MT_Sculpt_Menu(bpy.types.Menu):
         multires_box.label(text='Multires')
         multires_box.operator('dh.set_multires_viewport_max', text="Set Multires Max")
         multires_box.operator('dh.set_multires_viewport_zero', text="Set Multires Min")
+        multires_box.operator('dh.apply_multires_base', text="Apply Base")
 
         ob = context.active_object
         if ob and ob.modifiers:

--- a/DH_Toolkit/operators/__init__.py
+++ b/DH_Toolkit/operators/__init__.py
@@ -17,7 +17,11 @@ from .project_manager import (
     DH_PM_AddSubfolder,
     DH_PM_RemoveFolder,
 )
-from .multires_tools import SetMultiresViewportLevelsMax, SetMultiresViewportLevelsZero
+from .multires_tools import (
+    SetMultiresViewportLevelsMax,
+    SetMultiresViewportLevelsZero,
+    ApplyMultiresBase,
+)
 from .modifier_tools import DH_OP_CopyModifiers, DH_OP_toggle_modifiers_visibility
 from .transform_utils import DH_OP_ResetTransforms
 from .display_utils import DH_OP_ToggleWireframe, DH_OT_ToggleVisibilityOutliner, DH_OP_toggle_lock_camera, DH_OP_SwitchToShaderEditor
@@ -41,6 +45,7 @@ classes = (
     DH_OP_dcc_split_export, 
     SetMultiresViewportLevelsMax,
     SetMultiresViewportLevelsZero,
+    ApplyMultiresBase,
     DH_OP_CreateProjectDirectories,
     DH_OP_Proj_Manage,
     DH_OP_Project_Manager_Popup,

--- a/DH_Toolkit/operators/multires_tools.py
+++ b/DH_Toolkit/operators/multires_tools.py
@@ -9,8 +9,8 @@ class SetMultiresViewportLevelsMax(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     def execute(self, context):
-        selected_objects = context.selected_objects
-        for obj in selected_objects:
+        target_objects = context.selected_objects or context.visible_objects
+        for obj in target_objects:
             if obj.type == 'MESH':  # Only proceed for mesh objects
                 for modifier in obj.modifiers:
                     if modifier.type == 'MULTIRES':
@@ -29,12 +29,37 @@ class SetMultiresViewportLevelsZero(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     def execute(self, context):
-        selected_objects = context.selected_objects
-        for obj in selected_objects:
+        target_objects = context.selected_objects or context.visible_objects
+        for obj in target_objects:
             if obj.type == 'MESH':  # Only proceed for mesh objects
                 for modifier in obj.modifiers:
                     if modifier.type == 'MULTIRES':
                         modifier.levels = 0  # Set viewport levels to zero
         self.report({'INFO'}, "Viewport levels set to zero for Multires modifiers.")
+        return {'FINISHED'}
+
+
+## MULTIRES APPLY BASE
+
+class ApplyMultiresBase(bpy.types.Operator):
+    """Apply Base for Multires Modifiers"""
+    bl_idname = "dh.apply_multires_base"
+    bl_label = "Apply Base for Multires"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        target_objects = context.selected_objects or context.visible_objects
+        current_mode = context.mode
+        if current_mode != 'OBJECT':
+            bpy.ops.object.mode_set(mode='OBJECT')
+        for obj in target_objects:
+            if obj.type == 'MESH':
+                context.view_layer.objects.active = obj
+                for modifier in obj.modifiers:
+                    if modifier.type == 'MULTIRES':
+                        bpy.ops.object.multires_base_apply(modifier=modifier.name)
+        if current_mode != 'OBJECT':
+            bpy.ops.object.mode_set(mode=current_mode)
+        self.report({'INFO'}, "Applied base for Multires modifiers.")
         return {'FINISHED'}
 


### PR DESCRIPTION
## Summary
- improve multires level operators to default to visible meshes
- add an operator to apply the Multires base
- include the new operator in menus and registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e642cd86883299a914b43a76ca124