### PR TITLE
Add project directory preference

### DIFF
--- a/DH_Toolkit/__init__.py
+++ b/DH_Toolkit/__init__.py
@@ -3,7 +3,7 @@ bl_info = {
     "name": "DH_Toolkit",
     "description": "DH Tools",
     "author": "Darren Hing",
-    "version": (1, 1),
+    "version": (1, 2),
     "blender": (4,2 , 2),
     "location": "View3D",
     "category": "3D View"}

--- a/DH_Toolkit/operators/open_proj_dir.py
+++ b/DH_Toolkit/operators/open_proj_dir.py
@@ -8,16 +8,26 @@ class DH_OP_Open_Proj_Dir(bpy.types.Operator):
     bl_label = "Open Project"
 
     def execute(self, context):
-        # get the path of the current blend file
+        """Open the current project directory.
+
+        If the current Blender file has not been saved, fall back to the
+        default projects directory from the add-on preferences.
+        """
+
         filepath = bpy.data.filepath
 
-        # get the directory path
-        directory = os.path.dirname(filepath)
+        if filepath:
+            # Go up two folders from the .blend file location
+            directory = os.path.abspath(
+                os.path.join(os.path.dirname(filepath), os.pardir, os.pardir)
+            )
+        else:
+            prefs = context.preferences.addons["DH_Toolkit"].preferences
+            directory = prefs.default_projects_dir
 
-        # go up two folders
-        directory = os.path.abspath(os.path.join(directory, os.pardir, os.pardir))
+        if directory and os.path.isdir(directory):
+            os.startfile(directory)
+            return {'FINISHED'}
 
-        # open the directory in explorer
-        os.startfile(directory)
-
-        return {'FINISHED'}
+        self.report({'WARNING'}, "Project directory not found")
+        return {'CANCELLED'}

--- a/DH_Toolkit/operators/project_manager.py
+++ b/DH_Toolkit/operators/project_manager.py
@@ -92,6 +92,9 @@ class DH_OP_Proj_Manage(bpy.types.Operator):
     def invoke(self, context, event):
         global _active_pm_op
         _active_pm_op = self
+        if not self.directory:
+            prefs = context.preferences.addons["DH_Toolkit"].preferences
+            self.directory = prefs.default_projects_dir
         if not self.folder_items:
             self._add_default_folders()
         return context.window_manager.invoke_props_dialog(self)

--- a/DH_Toolkit/register/preferences.py
+++ b/DH_Toolkit/register/preferences.py
@@ -78,6 +78,14 @@ class DH_ToolkitPreferences(bpy.types.AddonPreferences):
         update=lambda self, context: self._update_keymap()
     )
 
+    # Default projects directory
+    default_projects_dir: bpy.props.StringProperty(
+        name="Default Projects Directory",
+        description="Base path for new projects and unsaved scenes",
+        subtype='DIR_PATH',
+        default=""
+    )
+
     # Shader Builder settings
     naming_separator: bpy.props.EnumProperty(
         name="Separator",
@@ -144,6 +152,12 @@ class DH_ToolkitPreferences(bpy.types.AddonPreferences):
         
         if self.key_type:
             box.label(text=f"Current key: {self.key_type}")
+
+        # Project settings
+        layout.separator()
+        proj_box = layout.box()
+        proj_box.label(text="Project Settings", icon='FILE_FOLDER')
+        proj_box.prop(self, "default_projects_dir")
 
         # Shader Builder settings (collapsed)
         layout.separator()


### PR DESCRIPTION
## Summary
- bump DH_Toolkit version to 1.2
- add `default_projects_dir` preference in addon settings
- expose project settings UI in preferences
- use default directory for project manager dialog
- open unsaved projects from preference path

## Testing
- `python -m py_compile DH_Toolkit/register/preferences.py DH_Toolkit/operators/open_proj_dir.py DH_Toolkit/operators/project_manager.py DH_Toolkit/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_686f7febc5d08329a9c75210c519eee9