### PR TITLE
Update Sculpt pie layout

### DIFF
--- a/DH_Toolkit/menus/sculpt_menu.py
+++ b/DH_Toolkit/menus/sculpt_menu.py
@@ -72,23 +72,26 @@ class DH_MT_Sculpt_Menu(bpy.types.Menu):
         # BOTTOM - Masking Tools
         col_bottom = pie.column()
         box = col_bottom.box()
-        box.label(text='Mask Tools')
 
-        row = box.row(align=True)
-        row.operator('dh.mask_extract', text="Extract Mask")
-        row.operator('mesh.paint_mask_slice', text="Mask Slice")
-        
         box.label(text="Mask Brushes:")
         row = box.row(align=True)
+        row.scale_y = 1.3
         row.operator("wm.tool_set_by_id", text="Box").name = "builtin.box_mask"
         row.operator("wm.tool_set_by_id", text="Lasso").name = "builtin.lasso_mask"
         row.operator("wm.tool_set_by_id", text="Line").name = "builtin.line_mask"
-        
+
         box.label(text="Transform:")
-        row = box.row(align=True)  # Create NEW row here
+        row = box.row(align=True)
+        row.scale_y = 1.3
         row.operator("wm.tool_set_by_id", text="Move").name = "builtin.move"
         row.operator("wm.tool_set_by_id", text="Rotate").name = "builtin.rotate"
         row.operator("wm.tool_set_by_id", text="Scale").name = "builtin.scale"
+
+        box.label(text='Mask Tools')
+        row = box.row(align=True)
+        row.scale_y = 1.3
+        row.operator('dh.mask_extract', text="Extract Mask")
+        row.operator('mesh.paint_mask_slice', text="Mask Slice")
 
         
         pivot_box = col_bottom.box() 


### PR DESCRIPTION
## Summary
- reorder masking tools section in Sculpt Toolkit pie menu
- enlarge buttons for mask brushes, transform, and mask tools

## Testing
- `python -m py_compile DH_Toolkit/menus/sculpt_menu.py`
- `python -m py_compile DH_Custom_Sculpt_Pie.py`


------
https://chatgpt.com/codex/tasks/task_e_686f883e4a8c8329acba689859874c29